### PR TITLE
Allow early exit for broken images

### DIFF
--- a/src/kodman/backend.py
+++ b/src/kodman/backend.py
@@ -276,7 +276,16 @@ class Backend:
                     break
                 self._log.info(f"Pod status: {read_resp.status.phase}")
                 time.sleep(1 / self._polling_freq)
-
+                events = self._client.list_namespaced_event(namespace=namespace)
+                for event in events.items:
+                    if event.involved_object.name == unique_pod_name:
+                        if event.type == "Warning":
+                            self.return_code = 1
+                            reason = event.type
+                            message = event.message
+                            self._log.debug(f"{reason}: {message}")
+                            print(message, file=sys.stderr)
+                            return unique_pod_name
             else:
                 raise TypeError("Unexpected response type")
 

--- a/src/kodman/backend.py
+++ b/src/kodman/backend.py
@@ -276,16 +276,18 @@ class Backend:
                     break
                 self._log.info(f"Pod status: {read_resp.status.phase}")
                 time.sleep(1 / self._polling_freq)
-                events = self._client.list_namespaced_event(namespace=namespace)
+                events = self._client.list_namespaced_event(
+                    namespace=namespace,
+                    field_selector=f"involvedObject.name={unique_pod_name}",
+                )
                 for event in events.items:
-                    if event.involved_object.name == unique_pod_name:
-                        if event.type == "Warning":
-                            self.return_code = 1
-                            reason = event.type
-                            message = event.message
-                            self._log.debug(f"{reason}: {message}")
-                            print(message, file=sys.stderr)
-                            return unique_pod_name
+                    if event.type == "Warning":
+                        self.return_code = 1
+                        reason = event.type
+                        message = event.message
+                        self._log.debug(f"{reason}: {message}")
+                        print(message, file=sys.stderr)
+                        return unique_pod_name
             else:
                 raise TypeError("Unexpected response type")
 

--- a/tests/data/responses.py
+++ b/tests/data/responses.py
@@ -33,3 +33,9 @@ For more examples and ideas, visit:
  https://docs.docker.com/get-started/"""
 
 mount = "test data"
+
+failed_command = (
+    "Error: failed to create containerd task: failed to create shim task: "
+    "OCI runtime create failed: runc create failed: unable to start container "
+    'process: exec: "bash": executable file not found in $PATH: unknown'
+)

--- a/tests/data/responses.py
+++ b/tests/data/responses.py
@@ -34,8 +34,6 @@ For more examples and ideas, visit:
 
 mount = "test data"
 
-failed_command = (
-    "Error: failed to create containerd task: failed to create shim task: "
-    "OCI runtime create failed: runc create failed: unable to start container "
-    'process: exec: "bash": executable file not found in $PATH: unknown'
-)
+failed_image = "Failed to pull image"
+
+failed_command = 'exec: "bash": executable file not found in $PATH: unknown'

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -135,6 +135,7 @@ def test_kodman_fail_image(data: Path):
 
     result = subprocess.run(cmd, capture_output=True, text=True)
     assert result.returncode == 1
+    assert responses.failed_image in result.stderr
 
 
 @pytest.mark.skipif(
@@ -152,4 +153,4 @@ def test_kodman_fail_command(data: Path):
 
     result = subprocess.run(cmd, capture_output=True, text=True)
     assert result.returncode == 1
-    assert result.stderr.strip() == responses.failed_command
+    assert responses.failed_command in result.stderr

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -120,3 +120,36 @@ def test_kodman_run_mount(data: Path):
     ]
 
     assert subprocess.check_output(cmd).decode().strip() == responses.mount
+
+
+@pytest.mark.skipif(
+    not KODMAN_SYSTEM_TESTING, reason="export KODMAN_SYSTEM_TESTING=true"
+)
+def test_kodman_fail_image(data: Path):
+    cmd = [
+        ENTRY_POINT,
+        "run",
+        "--rm",
+        "hello-worl",
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 1
+
+
+@pytest.mark.skipif(
+    not KODMAN_SYSTEM_TESTING, reason="export KODMAN_SYSTEM_TESTING=true"
+)
+def test_kodman_fail_command(data: Path):
+    cmd = [
+        ENTRY_POINT,
+        "run",
+        "--rm",
+        "--entrypoint",
+        "bash",
+        "hello-world",
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 1
+    assert result.stderr.strip() == responses.failed_command


### PR DESCRIPTION
Solves #12 

Example of use:
```
(.venv) [esq51579@pc0146 Kodman]$ kodman run --rm hello-worl && echo "Not run"
Failed to pull image "hello-worl": rpc error: code = NotFound desc = failed to pull and unpack image "docker.io/library/hello-worl:latest": failed to unpack image on snapshotter overlayfs: unexpected media type text/html for 
sha256:0ff21ac21a6c532c01691eb4ef2ae8c0c1aab539a6b07ca2960bc5e7aa7f2ca5: not found
(.venv) [esq51579@pc0146 Kodman]$ 
```