### PR TITLE
Stop failed run pods from boot-looping; harden --rm cleanup

### DIFF
--- a/src/kodman/__main__.py
+++ b/src/kodman/__main__.py
@@ -53,7 +53,6 @@ class Run(Command):
     def do(self, args, ctx, env, log):
         ctx.connect()
         log.debug(f"Image: {args.image}")
-        pod_name = ""
         k8s_command = []
         k8s_args = []
         if args.entrypoint:
@@ -75,10 +74,15 @@ class Run(Command):
             service_account=service_a if service_a else "",
         )
 
-        pod_name = ctx.run(options)
-        self.exit_code = ctx.return_code
-        if args.rm:
-            ctx.delete(DeleteOptions(pod_name))
+        try:
+            ctx.run(options)
+            self.exit_code = ctx.return_code
+        finally:
+            # Clean up even when run() raised part way through, otherwise a
+            # half-launched pod is left behind to be restarted/alerted on.
+            # ctx.pod_name is set by run() as soon as the name is known.
+            if args.rm and ctx.pod_name:
+                ctx.delete(DeleteOptions(ctx.pod_name))
 
 
 @engine.add_command

--- a/src/kodman/backend.py
+++ b/src/kodman/backend.py
@@ -51,6 +51,114 @@ class DeleteOptions:
     name: str
 
 
+INIT_CONTAINER_NAME = "wait-for-signal"
+
+
+def build_pod_manifest(
+    options: RunOptions, log: logging.Logger
+) -> tuple[str, dict[str, Any], list[dict[str, Path]]]:
+    """Build the one-shot pod manifest for a ``kodman run``.
+
+    Returns ``(unique_pod_name, pod_manifest, volumes)`` where ``volumes`` is
+    the cache of ``{"src", "dst"}`` mappings the caller later streams into the
+    init container with :func:`cp_k8s`.
+
+    ``restartPolicy`` is forced to ``"Never"``. kodman pods are run-to-completion
+    (docker-``run`` style), but the Pod default is ``restartPolicy=Always``, so a
+    failed launch would be restarted indefinitely by the kubelet — a
+    CrashLoopBackOff that boot-loops and spams alerts.
+    """
+    unique_pod_name = f"kodman-run-{hash(options)}"
+    pod_manifest: dict[str, Any] = {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": unique_pod_name,
+        },
+        "spec": {
+            "restartPolicy": "Never",
+            "initContainers": [
+                {
+                    "name": INIT_CONTAINER_NAME,
+                    "image": "busybox",
+                    "command": [
+                        "sh",
+                        "-c",
+                        "until [ -f /tmp/trigger ];"
+                        'do echo "Waiting for trigger...";'
+                        "sleep 1;"
+                        "done;"
+                        'echo "Trigger file found!"',
+                    ],
+                    "volumeMounts": [],
+                },
+            ],
+            "containers": [
+                {
+                    "image": options.image,
+                    "name": "kodman-exec",
+                    "volumeMounts": [],
+                }
+            ],
+            "volumes": [],
+        },
+    }
+
+    if options.command:
+        container = pod_manifest["spec"]["containers"][0]
+        container["command"] = options.command
+
+    if options.args:
+        pod_manifest["spec"]["containers"][0]["args"] = options.args
+
+    if options.service_account:
+        log.debug(f"Using serviceAccountNam: '{options.service_account}'")
+        pod_manifest["spec"]["serviceAccountName"] = options.service_account
+
+    volumes: list[dict[str, Path]] = []
+    if options.volumes:
+        for i, options_volume in enumerate(options.volumes):
+            process = options_volume.split(":")
+            src = Path(process[0]).resolve()
+            if not src.exists():
+                raise FileNotFoundError(f"{src} does not exist")
+            dst = src  # In case no dst, set same as src
+            try:
+                dst = Path(process[1])
+            except IndexError:
+                pass
+            if not dst.is_absolute():
+                raise ValueError("Destination path must be absolute")
+            log.info(f"Mount: {src} to {dst}")
+            if src.is_dir():
+                log.debug(f"Volume target {src} is a directory")
+                dst_mount = dst
+            else:
+                log.debug(f"Volume target {src} is a file")
+                dst_mount = dst.parent
+                if dst_mount == Path("/"):
+                    raise NotImplementedError(
+                        "Root mounting of files not supported by k8s 'emptyDir'"
+                    )
+
+            volumes.append({"src": src, "dst": dst})  # cache for later
+
+            pod_manifest["spec"]["initContainers"][0]["volumeMounts"].append(
+                {"name": f"shared-data-{i}", "mountPath": str(dst_mount)}
+            )
+            pod_manifest["spec"]["containers"][0]["volumeMounts"].append(
+                {"name": f"shared-data-{i}", "mountPath": str(dst_mount)}
+            )
+            pod_manifest["spec"]["volumes"].append(
+                {
+                    "name": f"shared-data-{i}",
+                    "emptyDir": {},
+                }
+            )
+
+    return unique_pod_name, pod_manifest, volumes
+
+
 def _iter_log_lines(resp):
     """Yield decoded log lines from a streamed (``_preload_content=False``)
     read_namespaced_pod_log response.
@@ -140,6 +248,10 @@ def get_incluster_context():
 class Backend:
     def __init__(self, log):
         self.return_code = 0
+        # Name of the pod created by the most recent run(). Set as early as
+        # possible so callers can still clean up (e.g. `--rm`) when run()
+        # raises part way through.
+        self.pod_name = ""
         self._log = log
         self._polling_freq = 1
         self._grace_period = 2  # Is this too aggressive?
@@ -167,94 +279,11 @@ class Backend:
         self._log.debug(f"  User: {self._context['user']}")
 
     def run(self, options: RunOptions) -> str:
-        unique_pod_name = f"kodman-run-{hash(options)}"
-        init_container_name = "wait-for-signal"
         namespace = self._context["namespace"]
-        pod_manifest: dict[str, Any] = {
-            "apiVersion": "v1",
-            "kind": "Pod",
-            "metadata": {
-                "name": unique_pod_name,
-            },
-            "spec": {
-                "initContainers": [
-                    {
-                        "name": init_container_name,
-                        "image": "busybox",
-                        "command": [
-                            "sh",
-                            "-c",
-                            "until [ -f /tmp/trigger ];"
-                            'do echo "Waiting for trigger...";'
-                            "sleep 1;"
-                            "done;"
-                            'echo "Trigger file found!"',
-                        ],
-                        "volumeMounts": [],
-                    },
-                ],
-                "containers": [
-                    {
-                        "image": options.image,
-                        "name": "kodman-exec",
-                        "volumeMounts": [],
-                    }
-                ],
-                "volumes": [],
-            },
-        }
-
-        if options.command:
-            container = pod_manifest["spec"]["containers"][0]
-            container["command"] = options.command
-
-        if options.args:
-            pod_manifest["spec"]["containers"][0]["args"] = options.args
-
-        if options.service_account:
-            self._log.debug(f"Using serviceAccountNam: '{options.service_account}'")
-            pod_manifest["spec"]["serviceAccountName"] = options.service_account
-
-        volumes: list[dict[str, Path]] = []
-        if options.volumes:
-            for i, options_volume in enumerate(options.volumes):
-                process = options_volume.split(":")
-                src = Path(process[0]).resolve()
-                if not src.exists():
-                    raise FileNotFoundError(f"{src} does not exist")
-                dst = src  # In case no dst, set same as src
-                try:
-                    dst = Path(process[1])
-                except IndexError:
-                    pass
-                if not dst.is_absolute():
-                    raise ValueError("Destination path must be absolute")
-                self._log.info(f"Mount: {src} to {dst}")
-                if src.is_dir():
-                    self._log.debug(f"Volume target {src} is a directory")
-                    dst_mount = dst
-                else:
-                    self._log.debug(f"Volume target {src} is a file")
-                    dst_mount = dst.parent
-                    if dst_mount == Path("/"):
-                        raise NotImplementedError(
-                            "Root mounting of files not supported by k8s 'emptyDir'"
-                        )
-
-                volumes.append({"src": src, "dst": dst})  # cache for later
-
-                pod_manifest["spec"]["initContainers"][0]["volumeMounts"].append(
-                    {"name": f"shared-data-{i}", "mountPath": str(dst_mount)}
-                )
-                pod_manifest["spec"]["containers"][0]["volumeMounts"].append(
-                    {"name": f"shared-data-{i}", "mountPath": str(dst_mount)}
-                )
-                pod_manifest["spec"]["volumes"].append(
-                    {
-                        "name": f"shared-data-{i}",
-                        "emptyDir": {},
-                    }
-                )
+        unique_pod_name, pod_manifest, volumes = build_pod_manifest(options, self._log)
+        init_container_name = INIT_CONTAINER_NAME
+        # Record the name immediately so a failed run() is still cleanable.
+        self.pod_name = unique_pod_name
 
         self._log.debug(f"Pod manifest = {pod_manifest}")
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,4 +1,41 @@
-from kodman.backend import _iter_log_lines
+import logging
+
+from kodman.backend import RunOptions, _iter_log_lines, build_pod_manifest
+
+_log = logging.getLogger("test")
+
+
+def test_build_pod_manifest_sets_restart_policy_never():
+    # A one-shot run pod must not be restarted on exit/failure, otherwise a
+    # failed launch CrashLoopBackOffs and spams alerts.
+    _, manifest, _ = build_pod_manifest(RunOptions(image="busybox"), _log)
+    assert manifest["spec"]["restartPolicy"] == "Never"
+
+
+def test_build_pod_manifest_basic_structure():
+    _, manifest, volumes = build_pod_manifest(RunOptions(image="alpine"), _log)
+    assert manifest["kind"] == "Pod"
+    container = manifest["spec"]["containers"][0]
+    assert container["image"] == "alpine"
+    assert container["name"] == "kodman-exec"
+    assert "command" not in container  # not requested
+    assert volumes == []
+
+
+def test_build_pod_manifest_applies_command_args_and_sa():
+    _, manifest, _ = build_pod_manifest(
+        RunOptions(
+            image="alpine",
+            command=["bash"],
+            args=["-c", "echo hi"],
+            service_account="runner",
+        ),
+        _log,
+    )
+    container = manifest["spec"]["containers"][0]
+    assert container["command"] == ["bash"]
+    assert container["args"] == ["-c", "echo hi"]
+    assert manifest["spec"]["serviceAccountName"] == "runner"
 
 
 class FakeStreamResponse:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,69 @@
+import argparse
+import logging
+
+import pytest
+
+from kodman.__main__ import engine
+
+# `@engine.add_command` registers an instance and rebinds the class name to
+# None, so reach the Run command class via the engine's registry.
+RunCommand = next(type(c) for c in engine._commands if type(c).__name__ == "Run")
+
+_log = logging.getLogger("test")
+
+
+class FakeBackend:
+    """Minimal stand-in for Backend that records delete() calls."""
+
+    def __init__(self, raise_on_run=False):
+        self.return_code = 0
+        self.pod_name = ""
+        self._raise_on_run = raise_on_run
+        self.deleted: list[str] = []
+
+    def connect(self):
+        pass
+
+    def run(self, options):
+        # Mirror the real backend: the name is known before any failure.
+        self.pod_name = "kodman-run-123"
+        if self._raise_on_run:
+            raise RuntimeError("launch failed")
+        return self.pod_name
+
+    def delete(self, options):
+        self.deleted.append(options.name)
+
+
+def _args(rm):
+    return argparse.Namespace(
+        entrypoint=None,
+        rm=rm,
+        volume=None,
+        image="busybox",
+        command=None,
+        args=[],
+    )
+
+
+_ENV = {"KODMAN_SERVICE_ACCOUNT": ""}
+
+
+def test_rm_deletes_pod_on_success():
+    ctx = FakeBackend()
+    RunCommand().do(_args(rm=True), ctx, _ENV, _log)
+    assert ctx.deleted == ["kodman-run-123"]
+
+
+def test_rm_deletes_pod_when_run_raises():
+    # The boot-loop fix: a failed launch must still be cleaned up under --rm.
+    ctx = FakeBackend(raise_on_run=True)
+    with pytest.raises(RuntimeError):
+        RunCommand().do(_args(rm=True), ctx, _ENV, _log)
+    assert ctx.deleted == ["kodman-run-123"]
+
+
+def test_no_rm_keeps_pod():
+    ctx = FakeBackend()
+    RunCommand().do(_args(rm=False), ctx, _ENV, _log)
+    assert ctx.deleted == []

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 import sys
@@ -280,3 +281,66 @@ def test_kodman_fail_command(data: Path):
     result = subprocess.run(cmd, capture_output=True, text=True)
     assert result.returncode == 1
     assert responses.failed_command in result.stderr
+
+
+def _kodman_pod_names() -> set[str]:
+    out = subprocess.check_output(["kubectl", "get", "pods", "-o", "json"]).decode()
+    pods = json.loads(out)["items"]
+    return {
+        p["metadata"]["name"]
+        for p in pods
+        if p["metadata"]["name"].startswith("kodman-run-")
+    }
+
+
+@pytest.mark.skipif(
+    not KODMAN_SYSTEM_TESTING, reason="export KODMAN_SYSTEM_TESTING=true"
+)
+def test_kodman_failed_pod_does_not_restart():
+    """Regression for the boot-loop bug.
+
+    A failed run-to-completion pod must settle in phase ``Failed`` with zero
+    restarts. Before the fix the pod inherited the Pod default
+    ``restartPolicy=Always``, so a failed container was restarted indefinitely
+    (CrashLoopBackOff) and spammed alerts. We omit ``--rm`` so the pod survives
+    for inspection, then delete it ourselves.
+    """
+    before = _kodman_pod_names()
+    cmd = [
+        ENTRY_POINT,
+        "run",
+        "--entrypoint",
+        "bash",
+        "ubuntu",
+        "-c",
+        "echo boom; exit 7",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    # Exit code is propagated even though the pod is left behind.
+    assert result.returncode == 7, (
+        f"exit={result.returncode}\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )
+
+    new_pods = _kodman_pod_names() - before
+    assert len(new_pods) == 1, f"expected one new pod, got {new_pods}"
+    pod_name = new_pods.pop()
+
+    try:
+        pod = json.loads(
+            subprocess.check_output(
+                ["kubectl", "get", "pod", pod_name, "-o", "json"]
+            ).decode()
+        )
+        assert pod["spec"]["restartPolicy"] == "Never"
+        assert pod["status"]["phase"] == "Failed", pod["status"]
+        exec_status = next(
+            c for c in pod["status"]["containerStatuses"] if c["name"] == "kodman-exec"
+        )
+        assert exec_status["restartCount"] == 0, exec_status
+    finally:
+        subprocess.run(
+            ["kubectl", "delete", "pod", pod_name, "--ignore-not-found"],
+            check=False,
+        )


### PR DESCRIPTION
kodman pods are run-to-completion (docker-run style) but the manifest never set restartPolicy, so they inherited the Pod default of Always. A failed launch was therefore restarted indefinitely by the kubelet (CrashLoopBackOff), boot-looping and spamming alerts.

- Force restartPolicy: "Never" so a failed/finished pod settles in Failed/Succeeded instead of restarting. Manifest construction is extracted into a pure, unit-testable build_pod_manifest().
- Make --rm cleanup robust: Backend records pod_name as soon as it is known, and Run.do deletes in a try/finally so a run() that raises part way through no longer leaks its pod.

Tests: manifest restartPolicy/structure (test_backend.py), cleanup on success/exception/no-rm (test_main.py), and a system test asserting a failed pod ends Failed with zero restarts (test_system.py).