### PR TITLE
Add --cpus, and sweep up pods that earlier runs left behind

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,39 @@ From outside of the cluster `kodman` will use your current Kubernetes context (t
 
 From inside the cluster `kodman` will use the serviceAccount mounted by default.
 
+## Pod cleanup
+
+`--rm` removes the pod when the run ends, whatever its exit code - as `docker
+run --rm` does. Without it the pod is left behind for inspection, and because
+Kubernetes has no garbage collector for a bare Pod (only a Job gets
+`ttlSecondsAfterFinished`), it would otherwise stay in the namespace forever.
+
+So every run first sweeps up after the ones before it. Pods kodman created -
+they carry `app.kubernetes.io/managed-by=kodman` - that have finished
+(`Succeeded` or `Failed`) and are older than a TTL are deleted. Pods that are
+still `Pending` or `Running` are never touched, whatever their age, since they
+may belong to a run happening right now.
+
+The TTL is one hour by default, leaving a window in which to inspect a failed
+run. Set `KODMAN_POD_TTL` to change it: seconds, `0` to reap finished pods
+immediately, or a negative value to disable the sweep.
+
+```
+KODMAN_POD_TTL=600 kodman run ubuntu true   # keep finished pods for 10 minutes
+```
+
+Pods created by kodman before this behaviour existed are unlabelled and so
+invisible to the sweep. Remove any strays once with:
+
+```
+kubectl get pods -o name | grep '^pod/kodman-run-' | xargs -r kubectl delete
+```
+
+An interrupted run (Ctrl-C, or the `SIGTERM` a cancelled CI job gets) deletes
+its pod even without `--rm`. Kubernetes cannot stop a pod short of deleting it,
+so the alternative is leaving it running and consuming the CPU it was given
+long after the client that asked for it has gone.
+
 ## Permissions
 
 A minimal Kubernetes RBAC role definition can be found in `.github/manifests`

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ echo "Mellon" > demo/token.txt
 kodman run -v ./demo:/demo --rm ubuntu bash -c "cat demo/token.txt"
 ```
 
+Ask for CPU, for work that needs more than the namespace hands out by default:
+```
+kodman run --cpus 4 --rm ubuntu nproc
+```
+Note that `nproc` still answers with the node's core count - a container is
+shown every core whether or not it may use them - so a build parallelised from
+that number will oversubscribe whatever `--cpus` allows.
+
 ## Usage:
 
 From outside of the cluster `kodman` will use your current Kubernetes context (the same as your current `kubectl` context).

--- a/src/kodman/__main__.py
+++ b/src/kodman/__main__.py
@@ -1,8 +1,24 @@
 import argparse
+import signal
+import sys
 
 from . import __version__
-from .backend import Backend, DeleteOptions, RunOptions
+from .backend import (
+    DEFAULT_POD_TTL_SECONDS,
+    Backend,
+    DeleteOptions,
+    RunOptions,
+    SweepOptions,
+)
 from .engine import ArgparseEngine, Command
+
+
+class RunInterruptedError(Exception):
+    """Raised in the main thread when a run is cut short by a signal."""
+
+    def __init__(self, signum: int):
+        super().__init__(f"interrupted by signal {signum}")
+        self.signum = signum
 
 
 class KodmanEngine(ArgparseEngine):
@@ -13,6 +29,7 @@ class KodmanEngine(ArgparseEngine):
             super().__init__()
 
         self.get_env("KODMAN_SERVICE_ACCOUNT", str)
+        self.get_env("KODMAN_POD_TTL", int)
         self._parser.add_argument(
             "-v",
             "--version",
@@ -59,6 +76,11 @@ class Run(Command):
 
     def do(self, args, ctx, env, log):
         ctx.connect()
+
+        # Reap what earlier runs left behind before adding to the pile.
+        ttl = env.get("KODMAN_POD_TTL")
+        ctx.sweep(SweepOptions(DEFAULT_POD_TTL_SECONDS if ttl is None else ttl))
+
         log.debug(f"Image: {args.image}")
         k8s_command = []
         k8s_args = []
@@ -82,14 +104,37 @@ class Run(Command):
             cpus=args.cpus if args.cpus else "",
         )
 
+        def _on_signal(signum, _frame):
+            raise RunInterruptedError(signum)
+
+        # Without this the pod outlives an interrupted client - a cancelled CI
+        # job or a Ctrl-C leaves it running, burning the CPU it was given until
+        # it finishes on its own. Kubernetes has no way to stop a pod short of
+        # deleting it, so an interrupted run removes its pod whether or not
+        # --rm was asked for.
+        previous = {
+            sig: signal.signal(sig, _on_signal)
+            for sig in (signal.SIGINT, signal.SIGTERM)
+        }
+        interrupted = False
+
         try:
             ctx.run(options)
             self.exit_code = ctx.return_code
+        except RunInterruptedError as interrupt:
+            interrupted = True
+            self.exit_code = 128 + interrupt.signum  # Shell convention
+            print(f"Interrupted, removing pod {ctx.pod_name}", file=sys.stderr)
         finally:
+            # Restore first: a second Ctrl-C during cleanup should kill kodman
+            # outright rather than re-enter this handler.
+            for sig, handler in previous.items():
+                signal.signal(sig, handler)
+
             # Clean up even when run() raised part way through, otherwise a
             # half-launched pod is left behind to be restarted/alerted on.
             # ctx.pod_name is set by run() as soon as the name is known.
-            if args.rm and ctx.pod_name:
+            if (args.rm or interrupted) and ctx.pod_name:
                 ctx.delete(DeleteOptions(ctx.pod_name))
 
 

--- a/src/kodman/__main__.py
+++ b/src/kodman/__main__.py
@@ -46,6 +46,13 @@ class Run(Command):
             action="append",
             help="Bind mount a volume into the container",
         )
+        parser_run.add_argument(
+            "--cpus",
+            type=str,
+            help="CPU the container may use, e.g. 4 or 500m. Without this the "
+            "pod takes whatever the namespace defaults to - often far less "
+            "than the node has, while the container still sees every core",
+        )
         parser_run.add_argument("image")
         parser_run.add_argument("command", nargs="?")
         parser_run.add_argument("args", nargs=argparse.REMAINDER, default=[])
@@ -72,6 +79,7 @@ class Run(Command):
             args=k8s_args,
             volumes=args.volume,
             service_account=service_a if service_a else "",
+            cpus=args.cpus if args.cpus else "",
         )
 
         try:

--- a/src/kodman/backend.py
+++ b/src/kodman/backend.py
@@ -4,12 +4,14 @@ import sys
 import tarfile
 import time
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 
 from kubernetes import client, config
 from kubernetes.client.models.core_v1_event_list import CoreV1EventList
 from kubernetes.client.models.v1_pod import V1Pod
+from kubernetes.client.models.v1_pod_list import V1PodList
 from kubernetes.client.rest import ApiException
 from kubernetes.stream import stream
 from urllib3 import HTTPResponse
@@ -52,7 +54,29 @@ class DeleteOptions:
     name: str
 
 
+@dataclass(frozen=True)
+class SweepOptions:
+    ttl_seconds: int
+
+
 INIT_CONTAINER_NAME = "wait-for-signal"
+
+# Marks every pod kodman creates, so a later run can find the ones an earlier
+# run left behind. Pods made before this label existed are invisible to the
+# sweep and have to be deleted by hand.
+MANAGED_BY_LABEL = "app.kubernetes.io/managed-by"
+MANAGED_BY_VALUE = "kodman"
+MANAGED_BY_SELECTOR = f"{MANAGED_BY_LABEL}={MANAGED_BY_VALUE}"
+
+# Phases in which a pod is finished with: nothing is running, nothing will run
+# again (restartPolicy is Never), and no kodman is still attached to its logs.
+# Anything else may belong to a run happening right now, so is never touched.
+TERMINAL_PHASES = ("Succeeded", "Failed")
+
+# How long a finished pod is kept for post-mortem inspection before the next
+# run reaps it. Without --rm a pod otherwise lives forever: a bare Pod has no
+# equivalent of a Job's ttlSecondsAfterFinished.
+DEFAULT_POD_TTL_SECONDS = 3600
 
 
 def build_pod_manifest(
@@ -63,6 +87,9 @@ def build_pod_manifest(
     Returns ``(unique_pod_name, pod_manifest, volumes)`` where ``volumes`` is
     the cache of ``{"src", "dst"}`` mappings the caller later streams into the
     init container with :func:`cp_k8s`.
+
+    The pod is labelled ``app.kubernetes.io/managed-by=kodman`` so that
+    :meth:`Backend.sweep` can find and reap it once it is finished with.
 
     ``restartPolicy`` is forced to ``"Never"``. kodman pods are run-to-completion
     (docker-``run`` style), but the Pod default is ``restartPolicy=Always``, so a
@@ -75,6 +102,7 @@ def build_pod_manifest(
         "kind": "Pod",
         "metadata": {
             "name": unique_pod_name,
+            "labels": {MANAGED_BY_LABEL: MANAGED_BY_VALUE},
         },
         "spec": {
             "restartPolicy": "Never",
@@ -290,6 +318,72 @@ class Backend:
         self._log.debug(f"  Cluster: {self._context['cluster']}")
         self._log.debug(f"  Namespace: {self._context['namespace']}")
         self._log.debug(f"  User: {self._context['user']}")
+
+    def sweep(self, options: SweepOptions) -> list[str]:
+        """Delete finished kodman pods left behind by earlier runs.
+
+        A pod outlives the kodman that created it whenever ``--rm`` was not
+        given, or the client was killed before it could clean up. Nothing in
+        Kubernetes collects a bare Pod, so they accumulate in the namespace
+        until somebody notices. Each run therefore reaps the leftovers of the
+        runs before it.
+
+        Only pods in a terminal phase older than ``ttl_seconds`` are removed:
+        a Pending or Running pod may belong to a kodman running right now.
+        A negative ttl disables the sweep. Returns the names deleted.
+
+        Failure here is never fatal - a namespace we cannot list or delete in
+        is a reason to warn and get on with the run, not to abandon it.
+        """
+        if options.ttl_seconds < 0:
+            self._log.debug("Pod sweep disabled")
+            return []
+
+        namespace = self._context["namespace"]
+        try:
+            pod_list = self._client.list_namespaced_pod(
+                namespace=namespace,
+                label_selector=MANAGED_BY_SELECTOR,
+            )
+        except ApiException as e:
+            self._log.warning(f"Could not list pods to sweep: {e}")
+            return []
+        if not isinstance(pod_list, V1PodList):  # Runtime type checking
+            # Warn rather than raise: a client whose response type moved under
+            # us must not take down every run, which is how the pod log stream
+            # broke on kubernetes 36.x (issue #51).
+            self._log.warning(f"Unexpected response type to sweep: {type(pod_list)}")
+            return []
+
+        now = datetime.now(UTC)
+        deleted = []
+        for pod in pod_list.items or []:
+            name = pod.metadata.name if pod.metadata else None
+            phase = pod.status.phase if pod.status else None
+            if not name or phase not in TERMINAL_PHASES:
+                continue
+
+            created = pod.metadata.creation_timestamp
+            age = (now - created).total_seconds() if created else 0
+            if age < options.ttl_seconds:
+                self._log.debug(f"Keeping {name}: {phase} for only {age:.0f}s")
+                continue
+
+            self._log.info(f"Sweeping {name}: {phase} for {age:.0f}s")
+            try:
+                self._client.delete_namespaced_pod(
+                    name=name,
+                    namespace=namespace,
+                    grace_period_seconds=self._grace_period,
+                )
+                deleted.append(name)
+            except ApiException as e:
+                if e.status != 404:  # Somebody else got there first
+                    self._log.warning(f"Could not sweep pod {name}: {e}")
+
+        if deleted:
+            self._log.info(f"Swept {len(deleted)} finished pod(s)")
+        return deleted
 
     def run(self, options: RunOptions) -> str:
         namespace = self._context["namespace"]

--- a/src/kodman/backend.py
+++ b/src/kodman/backend.py
@@ -22,6 +22,7 @@ class RunOptions:
     args: list[str] = field(default_factory=lambda: [])
     volumes: list[str] = field(default_factory=lambda: [])
     service_account: str = field(default_factory=lambda: "")
+    cpus: str = field(default_factory=lambda: "")
 
     def __hash__(self):
         hash_candidates = (
@@ -114,6 +115,18 @@ def build_pod_manifest(
     if options.service_account:
         log.debug(f"Using serviceAccountNam: '{options.service_account}'")
         pod_manifest["spec"]["serviceAccountName"] = options.service_account
+
+    if options.cpus:
+        # docker's --cpus is a ceiling on how much CPU the container may use,
+        # which k8s spells limits.cpu. Requesting the same amount rather than
+        # leaving the request to a LimitRange default keeps the pod off the
+        # throttle for work it has been promised, and makes it cost the
+        # cluster what it can actually use.
+        log.debug(f"Requesting cpu: '{options.cpus}'")
+        pod_manifest["spec"]["containers"][0]["resources"] = {
+            "requests": {"cpu": options.cpus},
+            "limits": {"cpu": options.cpus},
+        }
 
     volumes: list[dict[str, Path]] = []
     if options.volumes:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -38,6 +38,19 @@ def test_build_pod_manifest_applies_command_args_and_sa():
     assert manifest["spec"]["serviceAccountName"] == "runner"
 
 
+def test_build_pod_manifest_sets_cpu_when_asked():
+    _, manifest, _ = build_pod_manifest(RunOptions(image="alpine", cpus="4"), _log)
+    resources = manifest["spec"]["containers"][0]["resources"]
+    # requested as well as limited: a request left to a namespace default can
+    # be a fraction of the limit, and the container is then throttled
+    assert resources == {"requests": {"cpu": "4"}, "limits": {"cpu": "4"}}
+
+
+def test_build_pod_manifest_leaves_cpu_to_the_cluster_by_default():
+    _, manifest, _ = build_pod_manifest(RunOptions(image="alpine"), _log)
+    assert "resources" not in manifest["spec"]["containers"][0]
+
+
 class FakeStreamResponse:
     """Mimics the urllib3 response returned by read_namespaced_pod_log when
     _preload_content=False: .stream() yields arbitrary byte chunks."""

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,6 +1,22 @@
 import logging
+from datetime import UTC, datetime, timedelta
 
-from kodman.backend import RunOptions, _iter_log_lines, build_pod_manifest
+from kubernetes.client.models.v1_object_meta import V1ObjectMeta
+from kubernetes.client.models.v1_pod import V1Pod
+from kubernetes.client.models.v1_pod_list import V1PodList
+from kubernetes.client.models.v1_pod_status import V1PodStatus
+from kubernetes.client.rest import ApiException
+
+from kodman.backend import (
+    MANAGED_BY_LABEL,
+    MANAGED_BY_SELECTOR,
+    MANAGED_BY_VALUE,
+    Backend,
+    RunOptions,
+    SweepOptions,
+    _iter_log_lines,
+    build_pod_manifest,
+)
 
 _log = logging.getLogger("test")
 
@@ -49,6 +65,106 @@ def test_build_pod_manifest_sets_cpu_when_asked():
 def test_build_pod_manifest_leaves_cpu_to_the_cluster_by_default():
     _, manifest, _ = build_pod_manifest(RunOptions(image="alpine"), _log)
     assert "resources" not in manifest["spec"]["containers"][0]
+
+
+def test_build_pod_manifest_labels_the_pod_for_sweeping():
+    # Unlabelled pods cannot be found again, so cannot be reaped.
+    _, manifest, _ = build_pod_manifest(RunOptions(image="busybox"), _log)
+    assert manifest["metadata"]["labels"][MANAGED_BY_LABEL] == MANAGED_BY_VALUE
+
+
+def _pod(name, phase, age_seconds):
+    created = datetime.now(UTC) - timedelta(seconds=age_seconds)
+    return V1Pod(
+        metadata=V1ObjectMeta(name=name, creation_timestamp=created),
+        status=V1PodStatus(phase=phase),
+    )
+
+
+class FakePodApi:
+    """Stands in for CoreV1Api over the two calls sweep() makes."""
+
+    def __init__(self, pods, list_error=None, delete_error=None):
+        self._pods = pods
+        self._list_error = list_error
+        self._delete_error = delete_error
+        self.deleted: list[str] = []
+        self.selectors: list[str] = []
+
+    def list_namespaced_pod(self, namespace, label_selector=""):
+        if self._list_error:
+            raise self._list_error
+        self.selectors.append(label_selector)
+        return V1PodList(items=self._pods)
+
+    def delete_namespaced_pod(self, name, namespace, grace_period_seconds=None):
+        if self._delete_error:
+            raise self._delete_error
+        self.deleted.append(name)
+
+
+def _backend(api):
+    backend = Backend(_log)
+    backend._client = api
+    backend._context = {"namespace": "test-ns"}
+    return backend
+
+
+def test_sweep_removes_finished_pods_past_their_ttl():
+    api = FakePodApi([_pod("old-failed", "Failed", 7200)])
+    assert _backend(api).sweep(SweepOptions(ttl_seconds=3600)) == ["old-failed"]
+    assert api.deleted == ["old-failed"]
+    # Only ever kodman's own pods
+    assert api.selectors == [MANAGED_BY_SELECTOR]
+
+
+def test_sweep_keeps_finished_pods_within_their_ttl():
+    # The post-mortem window: a run that just failed is still inspectable.
+    api = FakePodApi([_pod("fresh-failed", "Failed", 60)])
+    assert _backend(api).sweep(SweepOptions(ttl_seconds=3600)) == []
+    assert api.deleted == []
+
+
+def test_sweep_never_touches_live_pods():
+    # These may belong to a kodman running right now, however old they are.
+    api = FakePodApi(
+        [_pod("running", "Running", 99999), _pod("pending", "Pending", 99999)]
+    )
+    assert _backend(api).sweep(SweepOptions(ttl_seconds=0)) == []
+    assert api.deleted == []
+
+
+def test_sweep_collects_succeeded_as_well_as_failed():
+    api = FakePodApi([_pod("done", "Succeeded", 7200), _pod("bad", "Failed", 7200)])
+    assert _backend(api).sweep(SweepOptions(ttl_seconds=3600)) == ["done", "bad"]
+
+
+def test_sweep_disabled_by_negative_ttl():
+    api = FakePodApi([_pod("old-failed", "Failed", 7200)])
+    assert _backend(api).sweep(SweepOptions(ttl_seconds=-1)) == []
+    assert api.selectors == []  # Not even listed
+
+
+def test_sweep_survives_a_namespace_it_cannot_list():
+    # Missing RBAC must warn and let the run proceed, not abort it.
+    api = FakePodApi([], list_error=ApiException(status=403))
+    assert _backend(api).sweep(SweepOptions(ttl_seconds=0)) == []
+
+
+def test_sweep_survives_an_unexpected_response_type():
+    # A client whose response type moves under us must not take the run down.
+    class OddApi:
+        def list_namespaced_pod(self, namespace, label_selector=""):
+            return {"items": []}  # Not the V1PodList the stubs promise
+
+    assert _backend(OddApi()).sweep(SweepOptions(ttl_seconds=0)) == []
+
+
+def test_sweep_survives_a_failed_delete():
+    api = FakePodApi(
+        [_pod("old-failed", "Failed", 7200)], delete_error=ApiException(status=404)
+    )
+    assert _backend(api).sweep(SweepOptions(ttl_seconds=0)) == []
 
 
 class FakeStreamResponse:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -40,6 +40,7 @@ def _args(rm):
         entrypoint=None,
         rm=rm,
         volume=None,
+        cpus=None,
         image="busybox",
         command=None,
         args=[],

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,10 @@
 import argparse
 import logging
+import signal
 
 import pytest
 
-from kodman.__main__ import engine
+from kodman.__main__ import RunInterruptedError, engine
 
 # `@engine.add_command` registers an instance and rebinds the class name to
 # None, so reach the Run command class via the engine's registry.
@@ -15,39 +16,50 @@ _log = logging.getLogger("test")
 class FakeBackend:
     """Minimal stand-in for Backend that records delete() calls."""
 
-    def __init__(self, raise_on_run=False):
+    def __init__(self, raise_on_run=None):
         self.return_code = 0
         self.pod_name = ""
         self._raise_on_run = raise_on_run
         self.deleted: list[str] = []
+        self.swept: list[int] = []
 
     def connect(self):
         pass
+
+    def sweep(self, options):
+        self.swept.append(options.ttl_seconds)
+        return []
 
     def run(self, options):
         # Mirror the real backend: the name is known before any failure.
         self.pod_name = "kodman-run-123"
         if self._raise_on_run:
-            raise RuntimeError("launch failed")
+            raise self._raise_on_run
         return self.pod_name
 
     def delete(self, options):
         self.deleted.append(options.name)
 
 
-def _args(rm):
-    return argparse.Namespace(
-        entrypoint=None,
-        rm=rm,
-        volume=None,
-        cpus=None,
-        image="busybox",
-        command=None,
-        args=[],
-    )
+def _args(rm, extra=()):
+    """Parse a real `kodman run` command line.
+
+    Built from the Run command's own parser rather than by hand, so a new
+    argument cannot leave these tests passing a Namespace that Run.do then
+    trips over (as --cpus did).
+    """
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="cli_command")
+    RunCommand().add(subparsers)
+
+    argv = ["run"]
+    if rm:
+        argv.append("--rm")
+    argv += [*extra, "busybox"]
+    return parser.parse_args(argv)
 
 
-_ENV = {"KODMAN_SERVICE_ACCOUNT": ""}
+_ENV = {"KODMAN_SERVICE_ACCOUNT": "", "KODMAN_POD_TTL": None}
 
 
 def test_rm_deletes_pod_on_success():
@@ -58,7 +70,7 @@ def test_rm_deletes_pod_on_success():
 
 def test_rm_deletes_pod_when_run_raises():
     # The boot-loop fix: a failed launch must still be cleaned up under --rm.
-    ctx = FakeBackend(raise_on_run=True)
+    ctx = FakeBackend(raise_on_run=RuntimeError("launch failed"))
     with pytest.raises(RuntimeError):
         RunCommand().do(_args(rm=True), ctx, _ENV, _log)
     assert ctx.deleted == ["kodman-run-123"]
@@ -68,3 +80,54 @@ def test_no_rm_keeps_pod():
     ctx = FakeBackend()
     RunCommand().do(_args(rm=False), ctx, _ENV, _log)
     assert ctx.deleted == []
+
+
+def test_args_reach_the_backend():
+    # Guards the wiring between the parser and RunOptions.
+    class Recorder(FakeBackend):
+        def run(self, options):
+            self.options = options
+            return super().run(options)
+
+    ctx = Recorder()
+    RunCommand().do(_args(rm=True, extra=["--cpus", "4"]), ctx, _ENV, _log)
+    assert ctx.options.image == "busybox"
+    assert ctx.options.cpus == "4"
+
+
+def test_interrupted_run_removes_pod_without_rm():
+    # A pod left running by a killed client keeps burning CPU, and k8s has no
+    # way to stop one short of deleting it.
+    ctx = FakeBackend(raise_on_run=RunInterruptedError(signal.SIGTERM))
+    command = RunCommand()
+    command.do(_args(rm=False), ctx, _ENV, _log)
+    assert ctx.deleted == ["kodman-run-123"]
+    assert command.exit_code == 128 + signal.SIGTERM
+
+
+def test_signal_handlers_are_restored():
+    original = {sig: signal.getsignal(sig) for sig in (signal.SIGINT, signal.SIGTERM)}
+    ctx = FakeBackend()
+    RunCommand().do(_args(rm=True), ctx, _ENV, _log)
+    assert {sig: signal.getsignal(sig) for sig in original} == original
+
+
+def test_signal_handlers_are_restored_after_failure():
+    original = signal.getsignal(signal.SIGTERM)
+    ctx = FakeBackend(raise_on_run=RuntimeError("launch failed"))
+    with pytest.raises(RuntimeError):
+        RunCommand().do(_args(rm=True), ctx, _ENV, _log)
+    assert signal.getsignal(signal.SIGTERM) is original
+
+
+def test_run_sweeps_with_default_ttl():
+    ctx = FakeBackend()
+    RunCommand().do(_args(rm=True), ctx, _ENV, _log)
+    assert ctx.swept == [3600]
+
+
+def test_pod_ttl_env_overrides_the_default():
+    ctx = FakeBackend()
+    env = {**_ENV, "KODMAN_POD_TTL": 0}
+    RunCommand().do(_args(rm=True), ctx, env, _log)
+    assert ctx.swept == [0]

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
 
 import pytest
@@ -342,5 +343,56 @@ def test_kodman_failed_pod_does_not_restart():
     finally:
         subprocess.run(
             ["kubectl", "delete", "pod", pod_name, "--ignore-not-found"],
+            check=False,
+        )
+
+
+@pytest.mark.skipif(
+    not KODMAN_SYSTEM_TESTING, reason="export KODMAN_SYSTEM_TESTING=true"
+)
+def test_kodman_sweeps_pods_left_by_earlier_runs():
+    """A run without ``--rm`` leaves its pod behind forever - nothing in
+    Kubernetes collects a bare Pod. The next run reaps it.
+
+    ``KODMAN_POD_TTL=0`` drops the post-mortem window so the sweep is
+    observable without waiting an hour for the default.
+    """
+    before = _kodman_pod_names()
+    subprocess.run(
+        [ENTRY_POINT, "run", "--entrypoint", "bash", "ubuntu", "-c", "exit 3"],
+        capture_output=True,
+        text=True,
+    )
+    orphans = _kodman_pod_names() - before
+    assert len(orphans) == 1, f"expected one leftover pod, got {orphans}"
+    orphan = orphans.pop()
+
+    try:
+        # The pod carries the label the sweep selects on.
+        pod = json.loads(
+            subprocess.check_output(
+                ["kubectl", "get", "pod", orphan, "-o", "json"]
+            ).decode()
+        )
+        assert pod["metadata"]["labels"]["app.kubernetes.io/managed-by"] == "kodman"
+
+        result = subprocess.run(
+            [ENTRY_POINT, "run", "--rm", "hello-world"],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "KODMAN_POD_TTL": "0"},
+        )
+        assert result.returncode == 0, result.stderr
+        # The sweep does not block the run on the delete completing, so give
+        # the API server a moment to finish removing the object.
+        for _ in range(30):
+            if orphan not in _kodman_pod_names():
+                break
+            time.sleep(1)
+        else:
+            pytest.fail(f"{orphan} survived the sweep")
+    finally:
+        subprocess.run(
+            ["kubectl", "delete", "pod", orphan, "--ignore-not-found"],
             check=False,
         )


### PR DESCRIPTION
The pod manifest never mentions `resources`, so every kodman pod takes the
namespace default. On the cluster behind the ibek-support-dls CI that default
is a request of 500m and a limit of 1 core: a compile that could use the node
gets one core, while the GitLab job pod that does nothing but wait for it and
stream its logs holds four.

`--cpus` mirrors docker's flag and sets `limits.cpu`. It sets `requests.cpu` to
the same value rather than leaving the request to a LimitRange default, because
a request that is a fraction of the limit is throttling of exactly the kind the
flag exists to remove.

Without the flag nothing changes - no `resources` key is added at all.

The README gains a note that `nproc` inside the pod still answers with the
node's core count whatever `--cpus` says, since that is what makes a build
parallelised from it oversubscribe. `ansible_processor_vcpus` reads the same
place, which is how `make -j96` ended up running on one core.

## Sweeping up pods that earlier runs left behind

Failed run pods were accumulating in `epics-iocs`. Without `--rm` a pod stays
in the namespace forever - Kubernetes has no garbage collector for a bare Pod,
only a Job gets `ttlSecondsAfterFinished` - so they pile up against the
namespace pod quota and bury the pods that matter.

- Every pod is now labelled `app.kubernetes.io/managed-by=kodman`, so kodman's
  own pods can be found again. Pods created before this are unlabelled and so
  invisible to the sweep; they need deleting by hand once.
- `Backend.sweep()` runs at the start of each run and deletes labelled pods
  that are `Succeeded`/`Failed` and older than a TTL. `Pending`/`Running` pods
  are never touched whatever their age - they may belong to a run happening
  right now. The TTL defaults to an hour, leaving a window in which to inspect
  a failed run, and is set by `KODMAN_POD_TTL` (`0` reaps at once, negative
  disables). A namespace kodman cannot list or delete in warns and lets the run
  go ahead rather than aborting it.
- `SIGINT`/`SIGTERM` are handled, so a Ctrl-C or a cancelled CI job deletes the
  pod even without `--rm`, exiting `128+signum`. Kubernetes cannot stop a pod
  short of deleting it, so the alternative is leaving it running and consuming
  the CPU it was given long after the client that asked for it has gone.

`test_main`'s hand-built `argparse.Namespace` is replaced by a real
`kodman run` command line parsed by the Run command's own parser, so the
fixture cannot drift from the CLI again as it did when `--cpus` was added.

Tested: unit tests for the flag and the untouched default; sweep TTL/phase/
label selection and its failure paths; signal cleanup and TTL wiring; and a
system test that a leftover pod is reaped by the next run.
