### PR TITLE
Say so when pod cleanup fails

### DIFF
--- a/src/kodman/backend.py
+++ b/src/kodman/backend.py
@@ -296,6 +296,18 @@ class Backend:
         self._log = log
         self._polling_freq = 1
         self._grace_period = 2  # Is this too aggressive?
+        self._delete_timeout: float = 60
+
+    def _warn(self, message: str):
+        """Report something the user needs to see whatever the log level.
+
+        Outside debug mode the log handler paints the rich status line, which
+        is transient - a warning sent only there is a warning nobody ever
+        reads. Cleanup that quietly fails looks exactly like cleanup that
+        worked, so these go to stderr as well.
+        """
+        self._log.warning(message)
+        print(message, file=sys.stderr)
 
     def connect(self):
         # Load config for user/serviceaccount
@@ -346,13 +358,13 @@ class Backend:
                 label_selector=MANAGED_BY_SELECTOR,
             )
         except ApiException as e:
-            self._log.warning(f"Could not list pods to sweep: {e}")
+            self._warn(f"Could not list pods to sweep: {e}")
             return []
         if not isinstance(pod_list, V1PodList):  # Runtime type checking
             # Warn rather than raise: a client whose response type moved under
             # us must not take down every run, which is how the pod log stream
             # broke on kubernetes 36.x (issue #51).
-            self._log.warning(f"Unexpected response type to sweep: {type(pod_list)}")
+            self._warn(f"Unexpected response type to sweep: {type(pod_list)}")
             return []
 
         now = datetime.now(UTC)
@@ -379,7 +391,7 @@ class Backend:
                 deleted.append(name)
             except ApiException as e:
                 if e.status != 404:  # Somebody else got there first
-                    self._log.warning(f"Could not sweep pod {name}: {e}")
+                    self._warn(f"Could not sweep pod {name}: {e}")
 
         if deleted:
             self._log.info(f"Swept {len(deleted)} finished pod(s)")
@@ -537,7 +549,14 @@ class Backend:
 
         return unique_pod_name
 
-    def delete(self, options: DeleteOptions):
+    def delete(self, options: DeleteOptions) -> bool:
+        """Delete a pod and wait for it to go, reporting whether it went.
+
+        A cleanup that fails must say so on stderr. Silently swallowing the
+        error - which is what this did - makes a --rm that never removes
+        anything indistinguishable from one that works, and the pods pile up
+        in the namespace with nothing in the CI log to explain why.
+        """
         namespace = self._context["namespace"]
         try:
             exists_resp = self._client.read_namespaced_pod(
@@ -549,6 +568,7 @@ class Backend:
                 namespace=namespace,
                 grace_period_seconds=self._grace_period,
             )
+            waited = 0
             while exists_resp:
                 self._log.info("Awaiting pod cleanup...")
                 try:
@@ -557,12 +577,26 @@ class Backend:
                         namespace=namespace,
                     )
                     time.sleep(1 / self._polling_freq)
+                    # A pod held by a finalizer never 404s, and this used to
+                    # spin on it forever, taking the whole run with it.
+                    waited += 1 / self._polling_freq
+                    if waited >= self._delete_timeout:
+                        self._warn(
+                            f"Pod {options.name} still present "
+                            f"{waited:.0f}s after being deleted"
+                        )
+                        return False
                 except ApiException as e:
                     if e.status == 404:
                         self._log.info(f"Pod {options.name} deleted successfully")
-                        break
+                        return True
                     else:
                         raise e
 
         except ApiException as e:
-            self._log.info(f"Error deleting pod: {e}")
+            # 403 here means the role can create pods but not delete them, so
+            # every --rm has been quietly leaving its pod behind.
+            self._warn(f"Could not delete pod {options.name}: {e}")
+            return False
+
+        return True

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -12,6 +12,7 @@ from kodman.backend import (
     MANAGED_BY_SELECTOR,
     MANAGED_BY_VALUE,
     Backend,
+    DeleteOptions,
     RunOptions,
     SweepOptions,
     _iter_log_lines,
@@ -165,6 +166,56 @@ def test_sweep_survives_a_failed_delete():
         [_pod("old-failed", "Failed", 7200)], delete_error=ApiException(status=404)
     )
     assert _backend(api).sweep(SweepOptions(ttl_seconds=0)) == []
+
+
+class FakeDeleteApi:
+    """Stands in for CoreV1Api over the calls delete() makes.
+
+    ``reads`` is the sequence of read_namespaced_pod outcomes: a pod, or an
+    ApiException to raise (404 once the pod has really gone).
+    """
+
+    def __init__(self, reads, delete_error=None, forever=False):
+        self._reads = list(reads)
+        self._delete_error = delete_error
+        self._forever = forever  # Never 404: the pod that will not go
+        self.deleted: list[str] = []
+
+    def read_namespaced_pod(self, name, namespace):
+        if self._forever:
+            return self._reads[0]
+        outcome = self._reads.pop(0) if self._reads else ApiException(status=404)
+        if isinstance(outcome, ApiException):
+            raise outcome
+        return outcome
+
+    def delete_namespaced_pod(self, name, namespace, grace_period_seconds=None):
+        if self._delete_error:
+            raise self._delete_error
+        self.deleted.append(name)
+
+
+def test_delete_reports_success():
+    api = FakeDeleteApi([_pod("gone", "Failed", 0), ApiException(status=404)])
+    assert _backend(api).delete(DeleteOptions("gone")) is True
+    assert api.deleted == ["gone"]
+
+
+def test_delete_reports_a_refused_delete(capsys):
+    # A role that can create pods but not delete them made every --rm a no-op,
+    # and said nothing about it. It has to reach stderr.
+    api = FakeDeleteApi([_pod("stuck", "Failed", 0)], delete_error=ApiException(403))
+    assert _backend(api).delete(DeleteOptions("stuck")) is False
+    assert "Could not delete pod stuck" in capsys.readouterr().err
+
+
+def test_delete_gives_up_on_a_pod_that_will_not_go(capsys):
+    # A pod held by a finalizer never 404s; this used to spin forever.
+    backend = _backend(FakeDeleteApi([_pod("zombie", "Failed", 0)], forever=True))
+    backend._polling_freq = 1000  # Don't really wait a minute
+    backend._delete_timeout = 0.05
+    assert backend.delete(DeleteOptions("zombie")) is False
+    assert "still present" in capsys.readouterr().err
 
 
 class FakeStreamResponse:


### PR DESCRIPTION
Failed run pods are surviving `--rm` in `epics-iocs`, while successful runs'
pods are cleaned up normally, and the CI log shows kodman exiting 1 rather
than being cancelled. Nothing in kodman branches on the exit code - `--rm`
deletes in a `finally` whatever happens - so we need to see what the cleanup
actually did. Right now we cannot, and that is the bug this fixes.

`delete()` caught every `ApiException` into `self._log.info(...)`. Outside
debug mode that handler paints the rich status line, which is transient, so a
cleanup failure produced no stderr, no exit code and nothing in the CI log. A
`--rm` that never removes anything is indistinguishable from one that works.
The sweep warnings added in 1.3.0 went to the same place and were just as
invisible.

- `Backend._warn()` logs *and* prints to stderr, for things the user has to
  see whatever the log level. `delete()` and `sweep()` use it, so a refused
  delete now reports the API error verbatim.
- `delete()` returns whether the pod actually went.
- The wait for the pod to disappear is bounded at 60s. It was
  `while exists_resp:` with no exit but a 404, so a pod held by a finalizer
  would spin there forever and take the whole run with it - a second way a run
  could hang, independent of the above.

This does not fix the leak; it makes the next failing run say which half of
the problem it is. A pod left behind *with* a warning gives us the API error.
A pod left behind with *no* warning proves `ctx.delete()` was never reached,
which pins it on the process dying first.

Tested: delete reports success, reports a refused delete on stderr, and gives
up on a pod that will not go.
